### PR TITLE
Add TXT upload for parsing custom report

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -28,21 +28,37 @@ const App: React.FC = () => {
   // Attempt to use useReactToPrint from the default export.
   // Using 'as any' to bypass TypeScript's type checking for this specific call,
   // focusing on resolving the JavaScript runtime module loading error first.
-  const handlePrint = (ReactToPrint as any).useReactToPrint({ 
+  const handlePrint = (ReactToPrint as any).useReactToPrint({
     content: () => componentToPrintRef.current,
     documentTitle: 'Marketing_Report',
   });
 
-  useEffect(() => {
+  const loadReportFromText = (text: string) => {
     try {
-      const parsedData = parseReportData(reportTxt);
+      const parsedData = parseReportData(text);
       setReportData(parsedData);
+      setError(null);
     } catch (e) {
-      console.error("Error parsing report data:", e);
-      setError("Failed to parse report data.");
-    } finally {
-      setLoading(false);
+      console.error('Error parsing report data:', e);
+      setError('Failed to parse report data.');
     }
+  };
+
+  const handleFileUpload = (file: File) => {
+    const reader = new FileReader();
+    reader.onload = () => {
+      const text = reader.result as string;
+      loadReportFromText(text);
+    };
+    reader.onerror = () => {
+      setError('Failed to read file.');
+    };
+    reader.readAsText(file);
+  };
+
+  useEffect(() => {
+    loadReportFromText(reportTxt);
+    setLoading(false);
   }, []);
 
   const getPageTitle = () => {
@@ -75,7 +91,12 @@ const App: React.FC = () => {
       <div className="flex h-screen bg-gray-900 text-gray-100">
         <Sidebar />
         <div className="flex-1 flex flex-col overflow-hidden">
-          <Header title={getPageTitle()} onDownloadPDF={handlePrint} reportDate={reportData.generalInfo.reportDate || "N/A"} />
+          <Header
+            title={getPageTitle()}
+            onDownloadPDF={handlePrint}
+            reportDate={reportData.generalInfo.reportDate || "N/A"}
+            onUploadFile={handleFileUpload}
+          />
           <main ref={componentToPrintRef} className="flex-1 overflow-x-hidden overflow-y-auto bg-gray-800 p-6 space-y-6 print:p-0 print:overflow-visible print:bg-white print:text-black">
             <Routes>
               <Route path="/" element={<OverviewPage />} />

--- a/components/Header.tsx
+++ b/components/Header.tsx
@@ -6,9 +6,25 @@ interface HeaderProps {
   title: string;
   onDownloadPDF: () => void;
   reportDate: string;
+  onUploadFile: (file: File) => void;
 }
 
-export const Header: React.FC<HeaderProps> = ({ title, onDownloadPDF, reportDate }) => {
+export const Header: React.FC<HeaderProps> = ({ title, onDownloadPDF, reportDate, onUploadFile }) => {
+  const fileInputRef = React.useRef<HTMLInputElement>(null);
+
+  const handleFileChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const file = e.target.files?.[0];
+    if (file) {
+      onUploadFile(file);
+      if (fileInputRef.current) {
+        fileInputRef.current.value = '';
+      }
+    }
+  };
+
+  const triggerFileInput = () => {
+    fileInputRef.current?.click();
+  };
   return (
     <header className="bg-gray-800 shadow-md print:hidden">
       <div className="container mx-auto px-6 py-4 flex justify-between items-center">
@@ -18,6 +34,19 @@ export const Header: React.FC<HeaderProps> = ({ title, onDownloadPDF, reportDate
             <CalendarDaysIcon className="w-5 h-5 mr-2 text-indigo-400" />
             <span>Report Date: {reportDate}</span>
           </div>
+          <button
+            onClick={triggerFileInput}
+            className="flex items-center bg-gray-700 hover:bg-gray-600 text-white font-medium py-2 px-4 rounded-lg transition-colors duration-200 focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:ring-opacity-50"
+          >
+            Upload TXT
+          </button>
+          <input
+            type="file"
+            accept=".txt"
+            ref={fileInputRef}
+            onChange={handleFileChange}
+            className="hidden"
+          />
           <button
             onClick={onDownloadPDF}
             className="flex items-center bg-indigo-600 hover:bg-indigo-700 text-white font-medium py-2 px-4 rounded-lg transition-colors duration-200 focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:ring-opacity-50"


### PR DESCRIPTION
## Summary
- enable uploading `.txt` files in the header
- parse uploaded file and display its metrics

## Testing
- `npm install`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_685402a2631c83329810b5d809800ff1